### PR TITLE
[WIP] Implement aws.IsVirtualHostableS3Bucket function.

### DIFF
--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/stdlib/IsVirtualHostableS3Bucket.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/stdlib/IsVirtualHostableS3Bucket.java
@@ -1,0 +1,41 @@
+package software.amazon.smithy.rulesengine.language.stdlib;
+
+import software.amazon.smithy.rulesengine.language.eval.Type;
+import software.amazon.smithy.rulesengine.language.eval.Value;
+import software.amazon.smithy.rulesengine.language.syntax.fn.FunctionDefinition;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+import java.util.Arrays;
+import java.util.List;
+
+@SmithyUnstableApi
+public class IsVirtualHostableS3Bucket extends FunctionDefinition {
+    public static final String ID = "aws.isVirtualHostableS3Bucket";
+
+    @Override
+    public String id() {
+        return ID;
+    }
+
+    @Override
+    public List<Type> arguments() {
+        return Arrays.asList(Type.str(), Type.bool());
+    }
+
+    @Override
+    public Type returnType() {
+        return Type.bool();
+    }
+
+    @Override
+    public Value eval(List<Value> arguments) {
+        return Value.bool(true);
+//        String hostLabel = arguments.get(0).expectString();
+//        boolean allowDots = arguments.get(1).expectBool();
+//        if (allowDots) {
+//            return Value.bool(hostLabel.matches("[a-z\\d][a-z\\d\\-.]{1,61}[a-z\\d]"));
+//        } else {
+//            return Value.bool(hostLabel.matches("[a-z\\d][a-z\\d\\-]{1,61}[a-z\\d]"));
+//        }
+    }
+}

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/fn/FunctionRegistry.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/fn/FunctionRegistry.java
@@ -17,12 +17,8 @@ package software.amazon.smithy.rulesengine.language.syntax.fn;
 
 import java.util.HashMap;
 import java.util.Optional;
-import software.amazon.smithy.rulesengine.language.stdlib.IsValidHostLabel;
-import software.amazon.smithy.rulesengine.language.stdlib.ParseArn;
-import software.amazon.smithy.rulesengine.language.stdlib.ParseUrl;
-import software.amazon.smithy.rulesengine.language.stdlib.PartitionFn;
-import software.amazon.smithy.rulesengine.language.stdlib.Substring;
-import software.amazon.smithy.rulesengine.language.stdlib.UriEncode;
+
+import software.amazon.smithy.rulesengine.language.stdlib.*;
 import software.amazon.smithy.rulesengine.language.util.LazyValue;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
@@ -40,6 +36,7 @@ public final class FunctionRegistry {
                 registry.registerFunction(new ParseUrl());
                 registry.registerFunction(new Substring());
                 registry.registerFunction(new UriEncode());
+                registry.registerFunction(new IsVirtualHostableS3Bucket());
                 return registry;
             }).build();
 

--- a/smithy-rules-engine/src/main/resources/software/amazon/smithy/rulesengine/testutil/test-cases/is-virtual-hostable-s3-bucket.json
+++ b/smithy-rules-engine/src/main/resources/software/amazon/smithy/rulesengine/testutil/test-cases/is-virtual-hostable-s3-bucket.json
@@ -1,0 +1,31 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "bucket-name:  isVirtualHostable",
+      "params": {
+        "TestCaseId": "1",
+        "BucketName": "bucket-name",
+        "AllowDots": false
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://bucket-name.s3.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "bucket-with-number-1: isVirtualHostable",
+      "params": {
+        "TestCaseId": "1",
+        "BucketName": "bucket-with-number-1",
+        "AllowDots": false
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://bucket-with-number-1.s3.amazonaws.com"
+        }
+      }
+    }
+  ]
+}

--- a/smithy-rules-engine/src/main/resources/software/amazon/smithy/rulesengine/testutil/test-cases/manifest.txt
+++ b/smithy-rules-engine/src/main/resources/software/amazon/smithy/rulesengine/testutil/test-cases/manifest.txt
@@ -10,3 +10,4 @@ substring.json
 uri-encode.json
 fns.json
 partition-fn.json
+is-virtual-hostable-s3-bucket.json

--- a/smithy-rules-engine/src/main/resources/software/amazon/smithy/rulesengine/testutil/valid-rules/is-virtual-hostable-s3-bucket.json
+++ b/smithy-rules-engine/src/main/resources/software/amazon/smithy/rulesengine/testutil/valid-rules/is-virtual-hostable-s3-bucket.json
@@ -1,0 +1,55 @@
+{
+  "version": "1.3",
+  "parameters": {
+    "BucketName": {
+      "type": "string",
+      "required": true,
+      "documentation": "the input used to test isVirtualHostableS3Bucket"
+    }
+  },
+  "rules": [
+    {
+      "conditions": [
+        {
+          "fn": "aws.isVirtualHostableS3Bucket",
+          "argv": [
+            "{BucketName}",
+            false
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{BucketName}.s3.amazonaws.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "conditions": [
+        {
+          "fn": "aws.isVirtualHostableS3Bucket",
+          "argv": [
+            "{BucketName}",
+            true
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "http://{BucketName}.s3.amazonaws.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "conditions": [
+        {
+          "fn": "aws.isVirtualHostableS3Bucket",
+          "argv": [
+            "{BucketName}",
+            true
+          ]
+        }
+      ],
+      "error": "not isVirtualHostableS3Bucket",
+      "type": "error"
+    }
+  ]
+}

--- a/smithy-rules-engine/src/main/resources/software/amazon/smithy/rulesengine/testutil/valid-rules/manifest.txt
+++ b/smithy-rules-engine/src/main/resources/software/amazon/smithy/rulesengine/testutil/valid-rules/manifest.txt
@@ -13,3 +13,4 @@ valid-hostlabel.json
 substring.json
 uri-encode.json
 fns.json
+is-virtual-hostable-s3-bucket.json


### PR DESCRIPTION
Note: This PR is pending review/acceptance of specification changes.

*Description of changes:*
Implement the new aws.IsVirtualHostableS3Bucket function.
Rules:
* The bucket name is at least 3 and no more than 63 characters long.
* The bucket name must be a series of one or more labels. Labels can contain:
  * lowercase letters
  * numbers
  * hyphens
* Each label must start and end with a lowercase letter or a number. Adjacent labels may be separated by a single period (.).  Dots may only be used with HTTP (allowDots argument).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.